### PR TITLE
feat: add context7 MCP server configuration to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,13 +29,18 @@ inputs:
     required: false
     default: |
       actions: read
-  mcp-servers:
+  mcp_config:
     description: 'MCP servers configuration for Claude Code'
     required: false
     default: |
-      - transport: sse
-        url: https://mcp.context7.com/sse
-        name: context7
+      {
+        "mcpServers": {
+          "context7": {
+            "transport": "sse",
+            "url": "https://mcp.context7.com/sse"
+          }
+        }
+      }
 
 runs:
   using: 'composite'
@@ -47,7 +52,7 @@ runs:
         claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
         additional_permissions: ${{ inputs.additional-permissions }}
         model: "claude-opus-4-1-20250805"
-        mcp_servers: ${{ inputs.mcp-servers }}
+        mcp_config: ${{ inputs.mcp_config }}
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,13 @@ inputs:
     required: false
     default: |
       actions: read
+  mcp-servers:
+    description: 'MCP servers configuration for Claude Code'
+    required: false
+    default: |
+      - transport: sse
+        url: https://mcp.context7.com/sse
+        name: context7
 
 runs:
   using: 'composite'
@@ -40,6 +47,7 @@ runs:
         claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
         additional_permissions: ${{ inputs.additional-permissions }}
         model: "claude-opus-4-1-20250805"
+        mcp_servers: ${{ inputs.mcp-servers }}
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Added MCP server configuration equivalent to:
```
claude mcp add --transport sse context7 https://mcp.context7.com/sse
```

This allows the Claude Code Action to use the context7 MCP server for enhanced capabilities.

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)